### PR TITLE
Add schema and example

### DIFF
--- a/example_typedef.json
+++ b/example_typedef.json
@@ -1,0 +1,91 @@
+{
+  "metadata": {
+    "app_name": "philip",
+    "author": "Kevin Weiss",
+    "version": "1.00.04"
+  },
+  "bitfields": [
+    {
+      "type_name": "the_example_typedef_t",
+      "type": "uint8_t",
+      "elements": [
+        {
+          "name": "basic_element",
+          "bits": 2
+        }
+      ]
+    }
+  ],
+  "typedefs": [
+    {
+      "type_name": "the_example_typedef_t",
+      "access": 1,
+      "elements": [
+        {
+          "name": "basic_element",
+          "type": "uint8_t"
+        },
+        {
+          "name": "access_3_element",
+          "type": "uint32_t",
+          "access": 3
+        },
+        {
+          "name": "access_0_element",
+          "type": "uint32_t",
+          "access": 0
+        },
+        {
+          "name": "specified_element",
+          "type": "uint32_t",
+          "default": 1,
+          "max": 10,
+          "min": 0,
+          "invalid": 11
+        },
+        {
+          "name": "array_element",
+          "type": "int32_t",
+          "array_size": 9
+        },
+        {
+          "name": "other_element",
+          "type": "uint16_t"
+        }
+      ]
+    },
+    {
+      "type_name": "mem_map_example_t",
+      "generate_mem_map": true,
+      "elements": [
+        {
+          "name": "an_element",
+          "type": "the_example_typedef_t"
+        },
+        {
+          "name": "other_element",
+          "type": "uint16_t"
+        }
+      ]
+    }
+  ],
+  "mem_map": [
+    {
+      "access": 0,
+      "bit_offset": 0,
+      "bits": 8,
+      "description": "Unique ID of the device",
+      "flag": "DEVICE_SPECIFIC",
+      "is_bitfield": false,
+      "name": [
+        "sys",
+        "sn",
+        "12"
+      ],
+      "offset": 0,
+      "size": 1,
+      "total_size": 12,
+      "type": "uint8_t"
+    }
+  ]
+}

--- a/example_typedef.json
+++ b/example_typedef.json
@@ -1,91 +1,99 @@
 {
-  "metadata": {
-    "app_name": "philip",
-    "author": "Kevin Weiss",
-    "version": "1.00.04"
-  },
-  "bitfields": [
-    {
-      "type_name": "the_example_typedef_t",
-      "type": "uint8_t",
-      "elements": [
-        {
-          "name": "basic_element",
-          "bits": 2
-        }
-      ]
-    }
-  ],
-  "typedefs": [
-    {
-      "type_name": "the_example_typedef_t",
-      "access": 1,
-      "elements": [
-        {
-          "name": "basic_element",
-          "type": "uint8_t"
-        },
-        {
-          "name": "access_3_element",
-          "type": "uint32_t",
-          "access": 3
-        },
-        {
-          "name": "access_0_element",
-          "type": "uint32_t",
-          "access": 0
-        },
-        {
-          "name": "specified_element",
-          "type": "uint32_t",
-          "default": 1,
-          "max": 10,
-          "min": 0,
-          "invalid": 11
-        },
-        {
-          "name": "array_element",
-          "type": "int32_t",
-          "array_size": 9
-        },
-        {
-          "name": "other_element",
-          "type": "uint16_t"
-        }
-      ]
+    "metadata":{
+        "app_name":"philip",
+        "author":"Kevin Weiss",
+        "version":"1.00.04"
     },
-    {
-      "type_name": "mem_map_example_t",
-      "generate_mem_map": true,
-      "elements": [
+    "bitfields":[
         {
-          "name": "an_element",
-          "type": "the_example_typedef_t"
+            "type_name":"example_bitfield_t",
+            "type":"uint8_t",
+            "elements":[
+                {
+                    "name":"basic_enable_reg",
+                    "bits":1
+                },
+                {
+                    "name":"example_prescale_reg",
+                    "bits":5
+                }
+            ]
+        }
+    ],
+    "typedefs":[
+        {
+            "type_name":"the_example_typedef_t",
+            "access":1,
+            "elements":[
+                {
+                    "name":"basic_element",
+                    "type":"uint8_t"
+                },
+                {
+                    "name":"access_3_element",
+                    "type":"uint32_t",
+                    "access":3
+                },
+                {
+                    "name":"access_0_element",
+                    "type":"uint32_t",
+                    "access":0
+                },
+                {
+                    "name":"specified_element",
+                    "type":"uint32_t",
+                    "default":1,
+                    "max":10,
+                    "min":0,
+                    "invalid":11
+                },
+                {
+                    "name":"array_element",
+                    "type":"int32_t",
+                    "array_size":9
+                },
+                {
+                    "name":"other_element",
+                    "type":"uint16_t"
+                },
+                {
+                    "name":"using_bitfield_type_element",
+                    "type":"example_bitfield_t"
+                }
+            ]
         },
         {
-          "name": "other_element",
-          "type": "uint16_t"
+            "type_name":"mem_map_example_t",
+            "generate_mem_map":true,
+            "elements":[
+                {
+                    "name":"an_element",
+                    "type":"the_example_typedef_t"
+                },
+                {
+                    "name":"other_element",
+                    "type":"uint16_t"
+                }
+            ]
         }
-      ]
-    }
-  ],
-  "mem_map": [
-    {
-      "access": 0,
-      "bit_offset": 0,
-      "bits": 8,
-      "description": "Unique ID of the device",
-      "flag": "DEVICE_SPECIFIC",
-      "is_bitfield": false,
-      "name": [
-        "sys",
-        "sn",
-        "12"
-      ],
-      "offset": 0,
-      "size": 1,
-      "total_size": 12,
-      "type": "uint8_t"
-    }
-  ]
+    ],
+    "mem_map":[
+        {
+            "access":0,
+            "bit_offset":0,
+            "bits":8,
+            "description":"Unique ID of the device",
+            "flag":"DEVICE_SPECIFIC",
+            "is_bitfield":false,
+            "name":[
+                "sys",
+                "sn",
+                "12"
+            ],
+            "offset":0,
+            "size":1,
+            "total_size":12,
+            "type":"uint8_t"
+        }
+    ]
 }

--- a/mem_map_schema.json
+++ b/mem_map_schema.json
@@ -1,0 +1,268 @@
+{
+    "$schema":"http://json-schema.org/draft-07/schema#",
+    "$id":"url_to_schema",
+    "title":"Typedef Generation",
+    "description":"Schema for typedef generation",
+    "definitions":{
+        "common_params":{
+            "properties":{
+                "access":{
+                    "type":"integer",
+                    "description":"Allows write access to register, example 0(0b00)=No access, 1(0b01)=basic access only, 2(0b10)=advanced access only, 3(0b11)=both basic and advanced",
+                    "minimum":0,
+                    "maximum":255
+                },
+                "min":{
+                    "type":[
+                        "number",
+                        "string"
+                    ],
+                    "description":"Minimum value of the element",
+                    "pattern":"^0[xX][0-9a-fA-F]+$"
+                },
+                "max":{
+                    "type":[
+                        "number",
+                        "string"
+                    ],
+                    "description":"Maximum value of the element",
+                    "pattern":"^0[xX][0-9a-fA-F]+$"
+                },
+                "default":{
+                    "type":[
+                        "number",
+                        "string"
+                    ],
+                    "description":"The default value of the element",
+                    "pattern":"^0[xX][0-9a-fA-F]+$"
+                },
+                "invalid":{
+                    "type":[
+                        "number",
+                        "string"
+                    ],
+                    "description":"An invalid number of the element used for negative testing",
+                    "pattern":"^0[xX][0-9a-fA-F]+$"
+                },
+                "flag":{
+                    "type":"string",
+                    "description":"Flags used for indicating things for the interface and tests"
+                }
+            }
+        }
+    },
+    "properties":{
+        "bitfields":{
+            "type":"array",
+            "description":"Bitfields to be generated",
+            "items":{
+                "properties":{
+                    "type_name":{
+                        "type":"string",
+                        "description":"The typedef name for the bitfield",
+                        "pattern":"^[a-z]+[0-9a-z_]*_t$"
+                    },
+                    "type":{
+                        "type":"string",
+                        "description":"The type of primitive to fit the bits in",
+                        "pattern":"^[a-z]+[0-9a-z_]*_t$"
+                    },
+                    "elements":{
+                        "type":"array",
+                        "description":"List of the bit elements",
+                        "minItems":1,
+                        "items":{
+                            "properties":{
+                                "name":{
+                                    "type":"string",
+                                    "description":"The variable name",
+                                    "pattern":"^[a-zA-Z]+[0-9a-z_A-Z]*$"
+                                },
+                                "bits":{
+                                    "type":"integer",
+                                    "minimum:":1
+                                }
+                            },
+                            "required":[
+                                "name",
+                                "bits"
+                            ]
+                        }
+                    }
+                },
+                "required":[
+                    "type_name",
+                    "elements"
+                ]
+            }
+        },
+        "typedefs":{
+            "type":"array",
+            "description":"Typedefs to generate",
+            "items":{
+                "allOf":[
+                    {
+                        "$ref":"#/definitions/common_params"
+                    },
+                    {
+                        "properties":{
+                            "type_name":{
+                                "type":"string",
+                                "description":"The name of the typedef struct",
+                                "minItems":1,
+                                "pattern":"^[a-z]+[0-9a-z_]*_t$"
+                            },
+                            "elements":{
+                                "type":"array",
+                                "description":"List of the elements in the typedef struct",
+                                "minItems":1,
+                                "items":{
+                                    "allOf":[
+                                        {
+                                            "$ref":"#/definitions/common_params"
+                                        },
+                                        {
+                                            "properties":{
+                                                "name":{
+                                                    "type":"string",
+                                                    "description":"The variable name",
+                                                    "pattern":"^[a-zA-Z]+[0-9a-z_A-Z]*$"
+                                                },
+                                                "type":{
+                                                    "type":"string",
+                                                    "description":"Either a primitive type or an already defined type",
+                                                    "pattern":"^[a-zA-Z]+[0-9a-z_A-Z]*$"
+                                                },
+                                                "array_size":{
+                                                    "type":"integer",
+                                                    "description":"Amount of elements in the array",
+                                                    "minimum":1
+                                                }
+                                            },
+                                            "required":[
+                                                "name",
+                                                "type"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "generate_mem_map":{
+                                "type":"boolean",
+                                "description":"Indicates if the memory map should from the typedef struct"
+                            },
+                            "size":{
+                                "type":"integer",
+                                "description":"Reserved amount of bytes for the struct",
+                                "minimum":1
+                            }
+                        },
+                        "required":[
+                            "type_name",
+                            "elements"
+                        ]
+                    }
+                ]
+            }
+        },
+        "mem_map":{
+            "type":"array",
+            "description":"Memory map of the expanded struct",
+            "items":{
+                "allOf":[
+                    {
+                        "$ref":"#/definitions/common_params"
+                    },
+                    {
+                        "properties":{
+                            "bit_offset":{
+                                "type":"integer",
+                                "description":"The number of bits in the bitfield",
+                                "minimum":0,
+                                "maximum":32
+                            },
+                            "bits":{
+                                "type":"integer",
+                                "description":"The amount of bits reserved for the variable",
+                                "minimum":0,
+                                "maximum":32
+                            },
+                            "is_bitfield":{
+                                "type":"boolean",
+                                "description":"If the variable is part of a bitfield"
+                            },
+                            "offset":{
+                                "type":"integer",
+                                "description":"Byte offset in the memory map",
+                                "minimum":0
+                            },
+                            "size":{
+                                "type":"integer",
+                                "description":"Size in bytes of the type of the variable",
+                                "minimum":0
+                            },
+                            "total_size":{
+                                "type":"integer",
+                                "description":"Total size in bytes of the variable or array",
+                                "minimum":0
+                            },
+                            "type":{
+                                "type":"string",
+                                "description":"Type of the variable",
+                                "pattern":"^[a-zA-Z]+[0-9a-z_A-Z]*$"
+                            },
+                            "name":{
+                                "type":"array",
+                                "description":"List of the elements in the typedef struct",
+                                "minItems":1,
+                                "items":{
+                                    "type":"string"
+                                }
+                            }
+                        },
+                        "required":[
+                            "name",
+                            "offset",
+                            "size",
+                            "total_size",
+                            "is_bitfield"
+                        ]
+                    }
+                ]
+            }
+        },
+        "metadata":{
+            "properties":{
+                "app_name":{
+                    "type":"string",
+                    "description":"Name of the application",
+                    "pattern":"^[a-zA-Z]+[0-9a-z_A-Z]*$"
+                },
+                "author":{
+                    "type":"string",
+                    "description":"Author name",
+                    "pattern":"^[a-zA-Z]+[0-9a-z A-Z]*$"
+                },
+                "email":{
+                    "type":"string",
+                    "description":"Contact email address",
+                    "pattern":"^[a-z0-9]+(\\.[_a-z0-9]+)*@[a-z0-9-]+(\\.[a-z0-9-]+)*(\\.[a-z]{2,15})$"
+                },
+                "version":{
+                    "type":"string",
+                    "description":"Name of the application",
+                    "pattern":"^(\\d+\\.)?(\\d+\\.)?(\\*|\\d+)$"
+                }
+            },
+            "required":[
+                "app_name",
+                "author",
+                "version"
+            ]
+        }
+    },
+    "required":[
+        "typedefs",
+        "metadata"
+    ]
+}


### PR DESCRIPTION
This adds a schema for the setup and config of the typedefs.  It specified the metadata, typedefs, bitfields and memory map layout.  It also adds a test for the schema that will eventually become a parsed example once the parser is updated to this structure.