### PR TITLE
Fix(bitfields): Fixes bitfield type offsets being ignored

### DIFF
--- a/example_typedef.json
+++ b/example_typedef.json
@@ -13,6 +13,24 @@
             ],
             "type": "uint8_t",
             "type_name": "example_bitfield_t"
+        },
+        {
+            "elements": [
+                {
+                    "bits": 6,
+                    "name": "basic_enable_reg"
+                },
+                {
+                    "bits": 7,
+                    "name": "example_prescale_reg"
+                },
+                {
+                    "bits": 1,
+                    "name": "same_offset_over_8_bit_offset"
+                }
+            ],
+            "type": "uint16_t",
+            "type_name": "longer_bitfield_t"
         }
     ],
     "mem_maps": [
@@ -114,7 +132,7 @@
                         "0",
                         "element_a"
                     ],
-                    "offset": 51,
+                    "offset": 52,
                     "type": "uint8_t",
                     "type_size": 1
                 },
@@ -125,7 +143,7 @@
                         "0",
                         "element_b_with_access_3"
                     ],
-                    "offset": 52,
+                    "offset": 53,
                     "type": "uint32_t",
                     "type_size": 4
                 },
@@ -138,7 +156,7 @@
                         "0",
                         "res"
                     ],
-                    "offset": 56,
+                    "offset": 57,
                     "total_size": 11,
                     "type": "uint8_t",
                     "type_size": 1
@@ -149,19 +167,19 @@
                         "array_of_special_type",
                         "1",
                         "element_a"
-                    ],
-                    "offset": 67,
-                    "type": "uint8_t",
-                    "type_size": 1
-                },
-                {
-                    "access": 3,
-                    "name": [
-                        "array_of_special_type",
-                        "1",
-                        "element_b_with_access_3"
                     ],
                     "offset": 68,
+                    "type": "uint8_t",
+                    "type_size": 1
+                },
+                {
+                    "access": 3,
+                    "name": [
+                        "array_of_special_type",
+                        "1",
+                        "element_b_with_access_3"
+                    ],
+                    "offset": 69,
                     "type": "uint32_t",
                     "type_size": 4
                 },
@@ -174,7 +192,7 @@
                         "1",
                         "res"
                     ],
-                    "offset": 72,
+                    "offset": 73,
                     "total_size": 11,
                     "type": "uint8_t",
                     "type_size": 1
@@ -186,7 +204,7 @@
                         "2",
                         "element_a"
                     ],
-                    "offset": 83,
+                    "offset": 84,
                     "type": "uint8_t",
                     "type_size": 1
                 },
@@ -197,7 +215,7 @@
                         "2",
                         "element_b_with_access_3"
                     ],
-                    "offset": 84,
+                    "offset": 85,
                     "type": "uint32_t",
                     "type_size": 4
                 },
@@ -210,17 +228,47 @@
                         "2",
                         "res"
                     ],
-                    "offset": 88,
+                    "offset": 89,
                     "total_size": 11,
                     "type": "uint8_t",
                     "type_size": 1
+                },
+                {
+                    "access": 1,
+                    "bit_offset": 0,
+                    "bits": 6,
+                    "name": [
+                        "longer_bitfield",
+                        "basic_enable_reg"
+                    ],
+                    "offset": 100
+                },
+                {
+                    "access": 1,
+                    "bit_offset": 6,
+                    "bits": 7,
+                    "name": [
+                        "longer_bitfield",
+                        "example_prescale_reg"
+                    ],
+                    "offset": 100
+                },
+                {
+                    "access": 1,
+                    "bit_offset": 13,
+                    "bits": 1,
+                    "name": [
+                        "longer_bitfield",
+                        "same_offset_over_8_bit_offset"
+                    ],
+                    "offset": 100
                 },
                 {
                     "access": 1,
                     "name": [
                         "other_element"
                     ],
-                    "offset": 99,
+                    "offset": 102,
                     "type": "uint16_t",
                     "type_size": 2
                 }
@@ -324,6 +372,10 @@
                     "array_size": 3,
                     "name": "array_of_special_type",
                     "type": "simple_t"
+                },
+                {
+                    "name": "longer_bitfield",
+                    "type": "longer_bitfield_t"
                 },
                 {
                     "name": "other_element",

--- a/memory_map_manager/mm_parser.py
+++ b/memory_map_manager/mm_parser.py
@@ -42,6 +42,8 @@ def _update_offsets(elements, offset=0):
         element["offset"] = offset
         if "elements" in element:
             offset = _update_offsets(element["elements"], offset)
+            if "bits" in element["elements"][0]:
+                offset += element["type_size"]
         elif "array" in element:
             for array_val in element["array"]:
                 offset = _update_offsets(array_val["elements"], offset)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="memory_map_manager",
-    version="0.0.1",
+    version="0.0.2",
     author="Kevin Weiss",
     author_email="kevin.weiss@haw-hamburg.de",
     license="MIT",

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,3 +1,8 @@
+Procedure for changes to example_typedef.json (please verify first)
+```
+python3 -m memory_map_manager.code_gen -cfgp example_typedef.json -ocfg example_typedef.json -ouc
+```
+
 Testing a package locally
 ```
 sudo pip3 uninstall memory_map_manager
@@ -7,7 +12,7 @@ sudo pip3 install dist/memory_map_manager-x.x.x.tar.gz
 
 Upload to pip
 ```
-python3 setup.py sdist bdist_wheel
+python3 setup.py sdist
 twine upload dist/*
 ```
 

--- a/tests/_regtest_outputs/test_example_typedef.test_import_regression.out
+++ b/tests/_regtest_outputs/test_example_typedef.test_import_regression.out
@@ -13,6 +13,24 @@
             ],
             "type": "uint8_t",
             "type_name": "example_bitfield_t"
+        },
+        {
+            "elements": [
+                {
+                    "bits": 6,
+                    "name": "basic_enable_reg"
+                },
+                {
+                    "bits": 7,
+                    "name": "example_prescale_reg"
+                },
+                {
+                    "bits": 1,
+                    "name": "same_offset_over_8_bit_offset"
+                }
+            ],
+            "type": "uint16_t",
+            "type_name": "longer_bitfield_t"
         }
     ],
     "mem_maps": [
@@ -114,7 +132,7 @@
                         "0",
                         "element_a"
                     ],
-                    "offset": 51,
+                    "offset": 52,
                     "type": "uint8_t",
                     "type_size": 1
                 },
@@ -125,7 +143,7 @@
                         "0",
                         "element_b_with_access_3"
                     ],
-                    "offset": 52,
+                    "offset": 53,
                     "type": "uint32_t",
                     "type_size": 4
                 },
@@ -138,7 +156,7 @@
                         "0",
                         "res"
                     ],
-                    "offset": 56,
+                    "offset": 57,
                     "total_size": 11,
                     "type": "uint8_t",
                     "type_size": 1
@@ -149,19 +167,19 @@
                         "array_of_special_type",
                         "1",
                         "element_a"
-                    ],
-                    "offset": 67,
-                    "type": "uint8_t",
-                    "type_size": 1
-                },
-                {
-                    "access": 3,
-                    "name": [
-                        "array_of_special_type",
-                        "1",
-                        "element_b_with_access_3"
                     ],
                     "offset": 68,
+                    "type": "uint8_t",
+                    "type_size": 1
+                },
+                {
+                    "access": 3,
+                    "name": [
+                        "array_of_special_type",
+                        "1",
+                        "element_b_with_access_3"
+                    ],
+                    "offset": 69,
                     "type": "uint32_t",
                     "type_size": 4
                 },
@@ -174,7 +192,7 @@
                         "1",
                         "res"
                     ],
-                    "offset": 72,
+                    "offset": 73,
                     "total_size": 11,
                     "type": "uint8_t",
                     "type_size": 1
@@ -186,7 +204,7 @@
                         "2",
                         "element_a"
                     ],
-                    "offset": 83,
+                    "offset": 84,
                     "type": "uint8_t",
                     "type_size": 1
                 },
@@ -197,7 +215,7 @@
                         "2",
                         "element_b_with_access_3"
                     ],
-                    "offset": 84,
+                    "offset": 85,
                     "type": "uint32_t",
                     "type_size": 4
                 },
@@ -210,17 +228,47 @@
                         "2",
                         "res"
                     ],
-                    "offset": 88,
+                    "offset": 89,
                     "total_size": 11,
                     "type": "uint8_t",
                     "type_size": 1
+                },
+                {
+                    "access": 1,
+                    "bit_offset": 0,
+                    "bits": 6,
+                    "name": [
+                        "longer_bitfield",
+                        "basic_enable_reg"
+                    ],
+                    "offset": 100
+                },
+                {
+                    "access": 1,
+                    "bit_offset": 6,
+                    "bits": 7,
+                    "name": [
+                        "longer_bitfield",
+                        "example_prescale_reg"
+                    ],
+                    "offset": 100
+                },
+                {
+                    "access": 1,
+                    "bit_offset": 13,
+                    "bits": 1,
+                    "name": [
+                        "longer_bitfield",
+                        "same_offset_over_8_bit_offset"
+                    ],
+                    "offset": 100
                 },
                 {
                     "access": 1,
                     "name": [
                         "other_element"
                     ],
-                    "offset": 99,
+                    "offset": 102,
                     "type": "uint16_t",
                     "type_size": 2
                 }
@@ -324,6 +372,10 @@
                     "array_size": 3,
                     "name": "array_of_special_type",
                     "type": "simple_t"
+                },
+                {
+                    "name": "longer_bitfield",
+                    "type": "longer_bitfield_t"
                 },
                 {
                     "name": "other_element",

--- a/tests/_regtest_outputs/test_example_typedef.test_updated_regression.out
+++ b/tests/_regtest_outputs/test_example_typedef.test_updated_regression.out
@@ -16,6 +16,28 @@
             "type": "uint8_t",
             "type_name": "example_bitfield_t",
             "type_size": 1
+        },
+        {
+            "elements": [
+                {
+                    "bit_offset": 0,
+                    "bits": 6,
+                    "name": "basic_enable_reg"
+                },
+                {
+                    "bit_offset": 6,
+                    "bits": 7,
+                    "name": "example_prescale_reg"
+                },
+                {
+                    "bit_offset": 13,
+                    "bits": 1,
+                    "name": "same_offset_over_8_bit_offset"
+                }
+            ],
+            "type": "uint16_t",
+            "type_name": "longer_bitfield_t",
+            "type_size": 2
         }
     ],
     "mem_maps": [
@@ -117,7 +139,7 @@
                         "0",
                         "element_a"
                     ],
-                    "offset": 51,
+                    "offset": 52,
                     "type": "uint8_t",
                     "type_size": 1
                 },
@@ -128,7 +150,7 @@
                         "0",
                         "element_b_with_access_3"
                     ],
-                    "offset": 52,
+                    "offset": 53,
                     "type": "uint32_t",
                     "type_size": 4
                 },
@@ -141,7 +163,7 @@
                         "0",
                         "res"
                     ],
-                    "offset": 56,
+                    "offset": 57,
                     "total_size": 11,
                     "type": "uint8_t",
                     "type_size": 1
@@ -152,19 +174,19 @@
                         "array_of_special_type",
                         "1",
                         "element_a"
-                    ],
-                    "offset": 67,
-                    "type": "uint8_t",
-                    "type_size": 1
-                },
-                {
-                    "access": 3,
-                    "name": [
-                        "array_of_special_type",
-                        "1",
-                        "element_b_with_access_3"
                     ],
                     "offset": 68,
+                    "type": "uint8_t",
+                    "type_size": 1
+                },
+                {
+                    "access": 3,
+                    "name": [
+                        "array_of_special_type",
+                        "1",
+                        "element_b_with_access_3"
+                    ],
+                    "offset": 69,
                     "type": "uint32_t",
                     "type_size": 4
                 },
@@ -177,7 +199,7 @@
                         "1",
                         "res"
                     ],
-                    "offset": 72,
+                    "offset": 73,
                     "total_size": 11,
                     "type": "uint8_t",
                     "type_size": 1
@@ -189,7 +211,7 @@
                         "2",
                         "element_a"
                     ],
-                    "offset": 83,
+                    "offset": 84,
                     "type": "uint8_t",
                     "type_size": 1
                 },
@@ -200,7 +222,7 @@
                         "2",
                         "element_b_with_access_3"
                     ],
-                    "offset": 84,
+                    "offset": 85,
                     "type": "uint32_t",
                     "type_size": 4
                 },
@@ -213,17 +235,47 @@
                         "2",
                         "res"
                     ],
-                    "offset": 88,
+                    "offset": 89,
                     "total_size": 11,
                     "type": "uint8_t",
                     "type_size": 1
+                },
+                {
+                    "access": 1,
+                    "bit_offset": 0,
+                    "bits": 6,
+                    "name": [
+                        "longer_bitfield",
+                        "basic_enable_reg"
+                    ],
+                    "offset": 100
+                },
+                {
+                    "access": 1,
+                    "bit_offset": 6,
+                    "bits": 7,
+                    "name": [
+                        "longer_bitfield",
+                        "example_prescale_reg"
+                    ],
+                    "offset": 100
+                },
+                {
+                    "access": 1,
+                    "bit_offset": 13,
+                    "bits": 1,
+                    "name": [
+                        "longer_bitfield",
+                        "same_offset_over_8_bit_offset"
+                    ],
+                    "offset": 100
                 },
                 {
                     "access": 1,
                     "name": [
                         "other_element"
                     ],
-                    "offset": 99,
+                    "offset": 102,
                     "type": "uint16_t",
                     "type_size": 2
                 }
@@ -440,14 +492,14 @@
                                 {
                                     "access": 1,
                                     "name": "element_a",
-                                    "offset": 51,
-                                    "type": "uint8_t",
-                                    "type_size": 1
-                                },
-                                {
-                                    "access": 3,
-                                    "name": "element_b_with_access_3",
                                     "offset": 52,
+                                    "type": "uint8_t",
+                                    "type_size": 1
+                                },
+                                {
+                                    "access": 3,
+                                    "name": "element_b_with_access_3",
+                                    "offset": 53,
                                     "type": "uint32_t",
                                     "type_size": 4
                                 },
@@ -456,7 +508,7 @@
                                     "array_size": 11,
                                     "description": "Reserved bytes",
                                     "name": "res",
-                                    "offset": 56,
+                                    "offset": 57,
                                     "total_size": 11,
                                     "type": "uint8_t",
                                     "type_size": 1
@@ -468,14 +520,14 @@
                                 {
                                     "access": 1,
                                     "name": "element_a",
-                                    "offset": 67,
-                                    "type": "uint8_t",
-                                    "type_size": 1
-                                },
-                                {
-                                    "access": 3,
-                                    "name": "element_b_with_access_3",
                                     "offset": 68,
+                                    "type": "uint8_t",
+                                    "type_size": 1
+                                },
+                                {
+                                    "access": 3,
+                                    "name": "element_b_with_access_3",
+                                    "offset": 69,
                                     "type": "uint32_t",
                                     "type_size": 4
                                 },
@@ -484,7 +536,7 @@
                                     "array_size": 11,
                                     "description": "Reserved bytes",
                                     "name": "res",
-                                    "offset": 72,
+                                    "offset": 73,
                                     "total_size": 11,
                                     "type": "uint8_t",
                                     "type_size": 1
@@ -496,14 +548,14 @@
                                 {
                                     "access": 1,
                                     "name": "element_a",
-                                    "offset": 83,
+                                    "offset": 84,
                                     "type": "uint8_t",
                                     "type_size": 1
                                 },
                                 {
                                     "access": 3,
                                     "name": "element_b_with_access_3",
-                                    "offset": 84,
+                                    "offset": 85,
                                     "type": "uint32_t",
                                     "type_size": 4
                                 },
@@ -512,7 +564,7 @@
                                     "array_size": 11,
                                     "description": "Reserved bytes",
                                     "name": "res",
-                                    "offset": 88,
+                                    "offset": 89,
                                     "total_size": 11,
                                     "type": "uint8_t",
                                     "type_size": 1
@@ -522,22 +574,52 @@
                     ],
                     "array_size": 3,
                     "name": "array_of_special_type",
-                    "offset": 51,
+                    "offset": 52,
                     "total_size": 48,
                     "type": "simple_t",
                     "type_size": 16
                 },
                 {
                     "access": 1,
+                    "elements": [
+                        {
+                            "access": 1,
+                            "bit_offset": 0,
+                            "bits": 6,
+                            "name": "basic_enable_reg",
+                            "offset": 100
+                        },
+                        {
+                            "access": 1,
+                            "bit_offset": 6,
+                            "bits": 7,
+                            "name": "example_prescale_reg",
+                            "offset": 100
+                        },
+                        {
+                            "access": 1,
+                            "bit_offset": 13,
+                            "bits": 1,
+                            "name": "same_offset_over_8_bit_offset",
+                            "offset": 100
+                        }
+                    ],
+                    "name": "longer_bitfield",
+                    "offset": 100,
+                    "type": "longer_bitfield_t",
+                    "type_size": 2
+                },
+                {
+                    "access": 1,
                     "name": "other_element",
-                    "offset": 99,
+                    "offset": 102,
                     "type": "uint16_t",
                     "type_size": 2
                 }
             ],
             "generate_mem_map": true,
             "type_name": "mem_map_example_t",
-            "type_size": 102
+            "type_size": 104
         },
         {
             "access": 1,


### PR DESCRIPTION
This fixes the bitfield type offsets being ignored, updates the test to test multibyte bitfields and increases the pip version.