### PR TITLE
fix(mm_parser): Fix missing records for mem_map, access, csv

### DIFF
--- a/example_typedef.json
+++ b/example_typedef.json
@@ -105,6 +105,16 @@
                 },
                 {
                     "access": 1,
+                    "name": [
+                        "an_element",
+                        "using_bitfield_type_element"
+                    ],
+                    "offset": 51,
+                    "type": "example_bitfield_t",
+                    "type_size": 1
+                },
+                {
+                    "access": 1,
                     "bit_offset": 0,
                     "bits": 1,
                     "name": [
@@ -232,6 +242,15 @@
                     "total_size": 11,
                     "type": "uint8_t",
                     "type_size": 1
+                },
+                {
+                    "access": 1,
+                    "name": [
+                        "longer_bitfield"
+                    ],
+                    "offset": 100,
+                    "type": "longer_bitfield_t",
+                    "type_size": 2
                 },
                 {
                     "access": 1,

--- a/memory_map_manager/mm_output_parser.py
+++ b/memory_map_manager/mm_output_parser.py
@@ -73,6 +73,7 @@ def parse_mem_map_to_access_c(mem_maps):
     for mem_map in deepcopy(mem_maps):
         a_str += "\nconst uint8_t %s_ACCESS[] = { \n" % mem_map['name'].upper()
         size = 0
+        map_size = 0
         for record in mem_map['records']:
             debug(record)
             if 'bit_offset' not in record:
@@ -84,9 +85,10 @@ def parse_mem_map_to_access_c(mem_maps):
                         a_str += ", "
                     a_str += "0x%02X" % record["access"]
                     size += 1
+                    map_size += 1
                 if record != mem_map['records'][-1]:
                     a_str += ","
                 a_str += " /* {} */\n".format('_'.join(record["name"]))
         a_str = a_str.rstrip(',')
-        a_str += "/* total size %d */\n};" % size
+        a_str += "/* total size %d */\n};" % map_size
     return a_str

--- a/memory_map_manager/mm_parser.py
+++ b/memory_map_manager/mm_parser.py
@@ -62,6 +62,8 @@ def _update_access(elements, access):
             overwrite_access = access
         if "elements" in element:
             _update_access(element["elements"], access)
+            if "bits" in element["elements"][0]:
+                element["access"] = overwrite_access
         elif "array" in element:
             for array_val in element["array"]:
                 _update_access(array_val["elements"], access)
@@ -89,6 +91,12 @@ def _parse_elements_to_records(elements, mem_map=None, name=None):
         name = []
     for element in elements:
         if "elements" in element:
+            if "bits" in element["elements"][0]:
+                mem_map.append(deepcopy(element))
+                mem_map[-1].pop("elements")
+                name.append(element["name"])
+                mem_map[-1]["name"] = deepcopy(name)
+                name.pop()
             name.append(element["name"])
             _parse_elements_to_records(element["elements"], mem_map, name)
             name.pop()
@@ -103,9 +111,7 @@ def _parse_elements_to_records(elements, mem_map=None, name=None):
         else:
             mem_map.append(deepcopy(element))
             name.append(element["name"])
-
             mem_map[-1]["name"] = deepcopy(name)
-
             name.pop()
     return mem_map
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="memory_map_manager",
-    version="0.0.2",
+    version="0.0.3",
     author="Kevin Weiss",
     author_email="kevin.weiss@haw-hamburg.de",
     license="MIT",

--- a/tests/_regtest_outputs/test_example_typedef.test_import_regression.out
+++ b/tests/_regtest_outputs/test_example_typedef.test_import_regression.out
@@ -105,6 +105,16 @@
                 },
                 {
                     "access": 1,
+                    "name": [
+                        "an_element",
+                        "using_bitfield_type_element"
+                    ],
+                    "offset": 51,
+                    "type": "example_bitfield_t",
+                    "type_size": 1
+                },
+                {
+                    "access": 1,
                     "bit_offset": 0,
                     "bits": 1,
                     "name": [
@@ -232,6 +242,15 @@
                     "total_size": 11,
                     "type": "uint8_t",
                     "type_size": 1
+                },
+                {
+                    "access": 1,
+                    "name": [
+                        "longer_bitfield"
+                    ],
+                    "offset": 100,
+                    "type": "longer_bitfield_t",
+                    "type_size": 2
                 },
                 {
                     "access": 1,

--- a/tests/_regtest_outputs/test_example_typedef.test_updated_regression.out
+++ b/tests/_regtest_outputs/test_example_typedef.test_updated_regression.out
@@ -112,6 +112,16 @@
                 },
                 {
                     "access": 1,
+                    "name": [
+                        "an_element",
+                        "using_bitfield_type_element"
+                    ],
+                    "offset": 51,
+                    "type": "example_bitfield_t",
+                    "type_size": 1
+                },
+                {
+                    "access": 1,
                     "bit_offset": 0,
                     "bits": 1,
                     "name": [
@@ -239,6 +249,15 @@
                     "total_size": 11,
                     "type": "uint8_t",
                     "type_size": 1
+                },
+                {
+                    "access": 1,
+                    "name": [
+                        "longer_bitfield"
+                    ],
+                    "offset": 100,
+                    "type": "longer_bitfield_t",
+                    "type_size": 2
                 },
                 {
                     "access": 1,


### PR DESCRIPTION
This fixes the missing records due to bitfields in the access.c, config file and csv.
Regression tests are also updated so this commit passes.
Increase the pip package number.