### PR TITLE
fix(mm_parser): Add type_size to bitfield in the records

### DIFF
--- a/memory_map_manager/mm_parser.py
+++ b/memory_map_manager/mm_parser.py
@@ -96,10 +96,17 @@ def _parse_elements_to_records(elements, mem_map=None, name=None):
                 mem_map[-1].pop("elements")
                 name.append(element["name"])
                 mem_map[-1]["name"] = deepcopy(name)
+                for bitfield in element["elements"]:
+                    mem_map.append(deepcopy(bitfield))
+                    mem_map[-1]["type_size"] = element["type_size"]
+                    name.append(bitfield["name"])
+                    mem_map[-1]["name"] = deepcopy(name)
+                    name.pop()
                 name.pop()
-            name.append(element["name"])
-            _parse_elements_to_records(element["elements"], mem_map, name)
-            name.pop()
+            else:
+                name.append(element["name"])
+                _parse_elements_to_records(element["elements"], mem_map, name)
+                name.pop()
         elif "array" in element:
             name.append(element["name"])
             for i, array_val in enumerate(element["array"]):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="memory_map_manager",
-    version="0.0.3",
+    version="0.0.4",
     author="Kevin Weiss",
     author_email="kevin.weiss@haw-hamburg.de",
     license="MIT",

--- a/tests/_regtest_outputs/test_example_typedef.test_updated_regression.out
+++ b/tests/_regtest_outputs/test_example_typedef.test_updated_regression.out
@@ -129,7 +129,8 @@
                         "using_bitfield_type_element",
                         "basic_enable_reg"
                     ],
-                    "offset": 51
+                    "offset": 51,
+                    "type_size": 1
                 },
                 {
                     "access": 1,
@@ -140,7 +141,8 @@
                         "using_bitfield_type_element",
                         "example_prescale_reg"
                     ],
-                    "offset": 51
+                    "offset": 51,
+                    "type_size": 1
                 },
                 {
                     "access": 1,
@@ -267,7 +269,8 @@
                         "longer_bitfield",
                         "basic_enable_reg"
                     ],
-                    "offset": 100
+                    "offset": 100,
+                    "type_size": 2
                 },
                 {
                     "access": 1,
@@ -277,7 +280,8 @@
                         "longer_bitfield",
                         "example_prescale_reg"
                     ],
-                    "offset": 100
+                    "offset": 100,
+                    "type_size": 2
                 },
                 {
                     "access": 1,
@@ -287,7 +291,8 @@
                         "longer_bitfield",
                         "same_offset_over_8_bit_offset"
                     ],
-                    "offset": 100
+                    "offset": 100,
+                    "type_size": 2
                 },
                 {
                     "access": 1,


### PR DESCRIPTION
WIP
Add type_size for bitfields in record export.  This is needed for the ll_mem_map_if in riot_pal.